### PR TITLE
env db

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  api:
+    container_name: cloudwatcher
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: cloudwatcher:latest
+    ports:
+      - "3000:3000"
+    networks:
+      - app
+    depends_on:
+      - postgres
+  postgres:
+    container_name: realo-postgres
+    image: postgres:14.7-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+    ports:
+      - '5432:5432'
+    networks:
+      - app
+    volumes:
+      - postgres:/var/lib/postgresql/data
+volumes:
+  postgres:
+    driver: local
+networks:
+  app:
+    driver: bridge

--- a/src/api/api.module.ts
+++ b/src/api/api.module.ts
@@ -4,6 +4,7 @@ import { UsersModule } from './users/users.module';
 import { User } from './users/user.entity';
 import { ConfigsModule } from './configs/configs.module';
 import { Config } from './configs/config.entity';
+import * as process from "process";
 
 @Module({
   imports: [
@@ -12,10 +13,10 @@ import { Config } from './configs/config.entity';
       database: 'postgres',
       entities: [User, Config],
       synchronize: true,
-      host: 'localhost',
-      port: 5432,
-      username: 'user',
-      password: 'pass',
+      host: process.env.DB_HOST,
+      port: +process.env.DB_PORT,
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
     }),
     UsersModule,
     ConfigsModule,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the database connection configuration to use environment variables and adds a Docker Compose file to the project.

### Detailed summary
- Database connection configuration now uses environment variables
- Added Docker Compose file to the project
- Docker Compose file defines two services: `api` and `postgres`
- `api` service is built from the project directory and exposes port `3000`
- `postgres` service uses the `postgres:14.7-alpine` image and exposes port `5432`
- Both services are added to the `app` network
- `api` service depends on `postgres` service

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->