### PR TITLE
docker publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,28 @@
+name: docker
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+        node: [18.16.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm run ci
+      - name: Docker Push
+        uses: mr-smithers-excellent/docker-build-push@v6
+        with:
+          image: abialiauski/cloudwatcher
+          tags: 0.0.$GITHUB_RUN_NUMBER, latest
+          dockerfile: Dockerfile
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a GitHub Actions workflow to build and push a Docker image on push to the master branch.

### Detailed summary
- Adds a GitHub Actions workflow to build and push a Docker image on push to the master branch
- Uses Node.js version 18.16.x
- Runs on Ubuntu 20.04
- Uses `actions/checkout@v3` to checkout the code
- Uses `actions/setup-node@v3` to set up Node.js
- Runs `npm run ci`
- Uses `mr-smithers-excellent/docker-build-push@v6` to build and push the Docker image
- Sets the image name to `abialiauski/cloudwatcher`
- Tags the image with the GitHub run number and `latest`
- Uses `Dockerfile` as the Dockerfile
- Pushes the image to `docker.io`
- Uses the `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets to authenticate with Docker Hub

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->